### PR TITLE
Implement service removal flag

### DIFF
--- a/README.md
+++ b/README.md
@@ -59,6 +59,14 @@ If you aren't interested in the output logs then run it with the `--showlogs=fal
 # jaas -image alexellis2/cows:latest --showlogs=false
 ```
 
+* Removing service after completion
+
+To remove the service after it completes, run with the `-rm` flag:
+
+```
+# ./jaas -image alexellis2/cows:latest -rm
+```
+
 * Running jaas in a container
 
 You can also run `jaas` in a container, but the syntax becomes slightly more verbose:
@@ -73,7 +81,7 @@ You can also run `jaas` in a container, but the syntax becomes slightly more ver
 Here are several features / enhancements on the roadmap, please make additional suggestions through Github issues.
 
 * [ ] Extract stdout/stderr etc from logs in human readable format similar to `docker logs`
-* [ ] Optionally delete service after fetching exit code/logs
+* [x] Optionally delete service after fetching exit code/logs
 * [ ] Support optional secrets through CLI flag
 * [ ] Validation around images which are not in local library
 * [x] Support passing environmental variables


### PR DESCRIPTION
## Description
Implementation of service removal flag for deleting the service after completion.

## Motivation and Context
Allows users to automatically have the service removed after it finishes running.

## How Has This Been Tested?
Tested with and without `-rm` flag and experienced expected results. No negative test yet (in case the removal doesn't succeed for some reason).

## Types of changes
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
- [x] My code follows the code style of this project.
- [x] My change requires a change to the documentation.
- [x] I have updated the documentation accordingly.
- [ ] I have added tests to cover my changes.
- [x] All new and existing tests passed.