### PR TITLE
Experimental check

### DIFF
--- a/app.go
+++ b/app.go
@@ -31,7 +31,6 @@ func (i *listFlag) Set(value string) error {
 	return nil
 }
 
-// Enable Docker's experimental mode in 1.13-rc before continuing.
 func main() {
 	var image string
 	var timeout int
@@ -60,6 +59,15 @@ func main() {
 	if err != nil {
 		log.Fatal("Error with Docker client.")
 	}
+
+	// Check that experimental mode is enabled on the daemon, fall back to no logging if not
+	if showlogs {
+		if versionInfo, _ := c.ServerVersion(context.Background()); !versionInfo.Experimental {
+			fmt.Println("Experimental daemon required to display service logs, falling back to no log display.")
+			showlogs = false
+		}
+	}
+	
 
 	spec := makeSpec(image, &envVars)
 	if len(network) > 0 {


### PR DESCRIPTION
## Description
Automatically check if the daemon is in experimental mode and if not, disable service logging.

## Motivation and Context
Provides a graceful option for anyone not running with an experimental daemon but who still wants the app to function correctly.

## How Has This Been Tested?
Tested with `showlogs` set to `true` and `false` against both experimental and non-experimental daemon modes.

## Types of changes
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I have added tests to cover my changes.
- [x] All new and existing tests passed.