### PR TITLE
Enable constraints for service placement

### DIFF
--- a/app.go
+++ b/app.go
@@ -39,7 +39,7 @@ func main() {
 	var network string
 	var removeService bool
 	var registry string
-
+	var constraints listFlag
 	var envVars listFlag
 
 	flag.Var(&envVars, "env", "environmental variables")
@@ -52,6 +52,8 @@ func main() {
 	flag.IntVar(&timeout, "timeout", 60, "ticks until we time out the service - default is 60 seconds")
 
 	flag.StringVar(&registry, "registryAuth", "", "pass your registry authentication")
+
+	flag.Var(&constraints, "constraint", "Placement constraints (e.g. node.labels.key==value)")
 
 	flag.Parse()
 
@@ -97,6 +99,12 @@ func main() {
 	if len(registry) > 0 {
 		createOptions.EncodedRegistryAuth = registry
 		fmt.Println("Using auth: " + registry)
+	}
+
+	placement := &swarm.Placement{}
+	if len(constraints) > 0 {
+		placement.Constraints = constraints
+		spec.TaskTemplate.Placement = placement
 	}
 
 	createResponse, _ := c.ServiceCreate(context.Background(), spec, createOptions)


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
Constraints can be passed to the service creation. We don't do any validation before pushing that to the swarm cluster.

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
[Feature request: Support service placement constraints](https://github.com/alexellis/jaas/issues/4)

## How Has This Been Tested?
I tested local on a mac and also with a swarm cluster with multiple nodes and different labels.
Also I compared the `docker service inspect` output.
You can run test it with:
`./jaas -constraint "engine.labels.x == y" -constraint "node.role == manager"  -registryAuth $encAuth -rm -image nginx`

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [X] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [X] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I have added tests to cover my changes.
- [ ] All new and existing tests passed.