### PR TITLE
Allows service log display when Docker API v1.29+ in non-experimental mode

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # Ad-hoc Jobs as a Service (JaaS)
 
-This project provides a simple Golang CLI tool that binds to the Docker Swarm API to create an ad-hoc/one-shot Service and then poll until it exits. Service logs can also be retrieved if the experimental feature is enabled on the Docker daemon.
+This project provides a simple Golang CLI tool that binds to the Docker Swarm API to create an ad-hoc/one-shot Service and then poll until it exits. Service logs can also be retrieved if the Docker daemon API version is greater than 1.29 or if the experimental feature is enabled on the Docker daemon.
 
 [![Build Status](https://travis-ci.org/alexellis/jaas.svg?branch=master)](https://travis-ci.org/alexellis/jaas)
 
@@ -28,7 +28,7 @@ See the [contributing guide](CONTRIBUTING.md) and do not raise a PR unless you'v
 
 Pre-requisites:
 
-* Docker 1.13 or newer (experimental mode must be enabled if accessing service logs)
+* Docker 1.13 or newer (experimental mode must be enabled if accessing service logs with Docker versions >= 1.13 and < 1.29)
 * [Go 1.9.2 (or Golang container)](https://golang.org/dl/)
 * Enable Swarm Mode (`docker swarm init`)
 
@@ -52,7 +52,7 @@ Now test `jaas` with `jaas --help`
 # jaas -rm -image alexellis2/cows:latest
 ```
 
-The `-rm` flag removes the Swarm service that was used to run your container. 
+The `-rm` flag removes the Swarm service that was used to run your container.
 
 > The exit code from your container will also be available, you can check it with `echo $?`
 
@@ -91,7 +91,7 @@ You can use `jaas` with Docker images in private registries or registries which 
 
 Just run `docker login` then pass the `-registryAuth` parameter and the encoded string you find in `~/.docker/config.json`.
 
-If you want to encode a string manually then do the following: 
+If you want to encode a string manually then do the following:
 
 ```bash
 $ export auth='{
@@ -103,7 +103,7 @@ $ export auth='{
 $ jaas -registryAuth="`echo $auth | base64`" -image my.reg.domain/hello-world:latest
 ```
 
-*Notes on images*
+_Notes on images_
 
 You can have a multi-node swarm but make sure whatever image you choose is available in an accessible registry.
 

--- a/app.go
+++ b/app.go
@@ -5,6 +5,7 @@ import (
 	"fmt"
 	"log"
 	"os"
+	"strconv"
 
 	"github.com/docker/docker/api/types"
 	"github.com/docker/docker/api/types/swarm"
@@ -73,9 +74,12 @@ func main() {
 	}
 
 	if showlogs {
-
-		if versionInfo.Experimental == false {
-			fmt.Println("Experimental daemon required to display service logs, falling back to no log display.")
+		apiVersion, parseErr := strconv.ParseFloat(versionInfo.APIVersion, 32)
+		if parseErr != nil {
+			apiVersion = 0
+		}
+		if apiVersion < 1.29 && versionInfo.Experimental == false {
+			fmt.Println("Experimental daemon or Docker API Version 1.29+ required to display service logs, falling back to no log display.")
 			showlogs = false
 		}
 	}


### PR DESCRIPTION
## Description
Added the a check for API version to allow Jaas to use service logs when available from the stable api.

## Motivation and Context
Reasons as described here: https://github.com/alexellis/jaas/issues/15

## How Has This Been Tested?
Tested by running `go build` locally then `./jaas -rm -image alexellis2/cows:latest`. Service logs were outputted as expected.

Tested on the following docker server versions:
```
Server:
 Engine:
  Version:	17.12.0-ce
  API version:	1.35 (minimum version 1.12)
  Go version:	go1.9.2
  Git commit:	c97c6d6
  Built:	Wed Dec 27 20:12:29 2017
  OS/Arch:	linux/amd64
  Experimental:	false
```

## Types of changes
- [x] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project. (think so but not 100% sure)
- [x] My change requires a change to the documentation.
- [x] I have updated the documentation accordingly.
- [ ] I have added tests to cover my changes. (Are there any tests?)
- [ ] All new and existing tests passed.

## Notes:
I haven't written any Go before so any pointers would be very helpful. Wasn't sure if there were any tests so let me know if I need to write some.