### PR TITLE
Add a jaas_ prefix to the service name

### DIFF
--- a/README.md
+++ b/README.md
@@ -73,7 +73,7 @@ To remove the service after it completes, run with the `--remove` or `-r` flag:
 ```
 # jaas run --image alexellis2/href-counter:latest --env url=http://blog.alexellis.io/
 
-Service created: peaceful_shirley (uva6bcqyubm1b4c80dghjhb44)
+Service created: jaas_peaceful_shirley (uva6bcqyubm1b4c80dghjhb44)
 ID:  uva6bcqyubm1b4c80dghjhb44  Update at:  2017-03-14 22:19:54.381973142 +0000 UTC
 ...
 
@@ -85,6 +85,8 @@ Printing service logs
 
 Removing service...
 ```
+
+To help you identify services created with jaas, the service name will be prefixed with jaas.
 
 * Docker authentication for registries
 

--- a/cmd/run.go
+++ b/cmd/run.go
@@ -16,6 +16,7 @@ import (
 	"github.com/docker/docker/api/types/filters"
 	"github.com/docker/docker/api/types/swarm"
 	"github.com/docker/docker/client"
+	"github.com/docker/docker/pkg/namesgenerator"
 
 	"github.com/spf13/cobra"
 )
@@ -127,7 +128,11 @@ func runTask(taskRequest TaskRequest) error {
 		spec.TaskTemplate.Placement = placement
 	}
 
-	createResponse, _ := c.ServiceCreate(context.Background(), spec, createOptions)
+	createResponse, err := c.ServiceCreate(context.Background(), spec, createOptions)
+	if err != nil {
+		fmt.Println(err)
+		os.Exit(1)
+	}
 	opts := types.ServiceInspectOptions{InsertDefaults: true}
 
 	service, _, _ := c.ServiceInspectWithRaw(context.Background(), createResponse.ID, opts)
@@ -153,6 +158,7 @@ func makeSpec(image string, envVars []string) swarm.ServiceSpec {
 			},
 		},
 	}
+	spec.Name = "jaas_" + namesgenerator.GetRandomName(0)
 	return spec
 }
 


### PR DESCRIPTION
We will generate the service name on the client and prefix it with
jaas_. If by chance this name already exists we will exit and print the
informing error. We might introduce a retry logic in the future.

Signed-off-by: Dominik Dingel <dominik.dingel@gmail.com>

<!--- Provide a general summary of your changes in the Title above -->

## Description
We generate the name and prefix it with jaas

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
https://github.com/alexellis/jaas/issues/22

## How Has This Been Tested?
Manual created a service and let jaas create an additional service with a given name (changed in code).

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [X] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [X] My code follows the code style of this project.
- [X] My change requires a change to the documentation.
- [X] I have updated the documentation accordingly.
- [ ] I have added tests to cover my changes.
- [ ] All new and existing tests passed.