### PR TITLE
Command line option for adding secrets to one-shot task

### DIFF
--- a/README.md
+++ b/README.md
@@ -113,6 +113,29 @@ $ export auth='{
 $ jaas run --registry="`echo $auth | base64`" --image my.reg.domain/hello-world:latest
 ```
 
+* Adding secret to service
+
+To give the service access to an _existing secret_. run with the `--secret` or `-s` flag:
+
+```
+# echo "p4ssword" > pass_file
+# docker secret create my_secret pass_file
+# jaas run --image alexellis2/href-counter:latest --env url=http://blog.alexellis.io/ --secret my_secret --command "cat /run/secrets/my_secret"
+
+Service created: priceless_tesla (f8gheat9f3b8cnnsjy9dth9y7)
+ID:  f8gheat9f3b8cnnsjy9dth9y7  Update at:  2018-06-29 16:41:13.723257461 +0000 UTC
+...........
+
+Exit code: 0
+State: complete
+
+
+Printing service logs
+(2018-06-29T16:41:19.057738088Z p4ssword
+
+Removing service...
+```
+
 _Notes on images_
 
 You can have a multi-node swarm but make sure whatever image you choose is available in an accessible registry.

--- a/cmd/types.go
+++ b/cmd/types.go
@@ -11,6 +11,7 @@ type TaskRequest struct {
 	EnvVars     []string
 	Mounts      []string
 	EnvFiles    []string
+	Secrets     []string
 
 	ShowLogs      bool
 	Timeout       string


### PR DESCRIPTION
Signed-off-by: Marcelo Pereira <marcelovitor.pereira@gmail.com>

<!--- Provide a general summary of your changes in the Title above -->

## Description
The `--secret` or `-s` flag was included for adding secrets to a one-shot service. The syntax is
```
jaas --image my_image --secret secret_name=secret_file --secret
```
, where `secret_name` is the name of a secret that was previously created (an error message is returned if a secret with the given name is not found) and `secret_file` is the name of the file with the secret that will be available inside the container. All such files are available in the container under the `/run/secrets/` directory.

The flag supports multiple secrets, as follows:
```
jaas --image my_image --secret secret_name=secret_file --secret another_secret=another_secret_file
```

## Motivation and Context
This addresses the issue raised in https://github.com/alexellis/jaas/issues/14 and allows for one-shot tasks to have access to docker secrets.

## How Has This Been Tested?
This was tested on Ubuntu 18.04 with Go version go1.10.3 linux/amd64. Tests were done by running the command in the following cases:
- The command was run without the `--secret` flag
- Command was run with the `--secret` flag referencing a secret that didn't exist, raising an error
- Command was run with a `--secret` flag referencing a secret that did exist, and the `--command` flag was used to `cat` the contents of the secret file
- The command was run with multiple `--secret` flags and `cat` was used to print the contents of each of the files.

## Types of changes

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] My code follows the code style of this project.
- [x] My change requires a change to the documentation.
- [x] I have updated the documentation accordingly.
- [ ] I have added tests to cover my changes.
- [x] All new and existing tests passed.
