### PR TITLE
Fix API version check

### DIFF
--- a/cmd/run.go
+++ b/cmd/run.go
@@ -107,7 +107,7 @@ func runTask(taskRequest TaskRequest) error {
 	}
 
 	if taskRequest.ShowLogs {
-		apiVersion, parseErr := strconv.ParseFloat(versionInfo.APIVersion, 32)
+		apiVersion, parseErr := strconv.ParseFloat(versionInfo.APIVersion, 64)
 		if parseErr != nil {
 			apiVersion = 0
 		}


### PR DESCRIPTION
Signed-off-by: Takafumi Koyama <koyama@unirobot.com>

<!--- Provide a general summary of your changes in the Title above -->

## Description
<!--- Describe your changes in detail -->
Changed the `bitSize` argument of `parseFloat` from 32 to 64 when converting version string to float64. 
This makes `apiVersion < 1.29` false as expected, when the API version is 1.29,
since apiVersion and the literal `1.29` have the same 64 bit float precision.

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->
Fixes #42.

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
I tested the fix on Ubuntu 16.04 with docker 17.04 (API version 1.29),
running the following command.

```terminal
# jaas run -i hello-world
```

The logs were successfully displayed.

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I have added tests to cover my changes.
- [ ] All new and existing tests passed.
